### PR TITLE
fix: 메뉴 사이드바(active)수정

### DIFF
--- a/src/components/common/sidebar/index.tsx
+++ b/src/components/common/sidebar/index.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as S from "./index.style";
+import useSidebar from 'src/hooks/sidebar/useSidebar';
 
 import SopoLogo from "src/assets/imgs/sidebar/sopo_logo.svg";
 import HomeIcon from "src/assets/imgs/sidebar/home.svg";
@@ -10,27 +11,10 @@ import CompetitionIcon from "src/assets/imgs/sidebar/competition.svg";
 import LogoutIcon from "src/assets/imgs/sidebar/logouticon.svg";
 
 const Index = () => {
-  const [activeItem, setActiveItem] = useState<string | null>(null);
   const navigate = useNavigate();
-  const location = useLocation();
-
-  useEffect(() => {
-    const path = location.pathname;
-    if (path === '/main') {
-      setActiveItem('home');
-    } else if (path === '/seniortojunior') {
-      setActiveItem('mentor');
-    } else if (path.startsWith('/portfolio')) {
-      setActiveItem('portfolio');
-    } else if (path.startsWith('/competition')) {
-      setActiveItem('competition');
-    } else {
-      setActiveItem(null);
-    }
-  }, [location.pathname]);
+  const activeItem = useSidebar();
 
   const handleMenuItemClick = (item: string, path: string) => {
-    setActiveItem(item);
     navigate(path);
   };
 

--- a/src/hooks/sidebar/useSidebar.ts
+++ b/src/hooks/sidebar/useSidebar.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const useSidebar = () => {
+  const [activeItem, setActiveItem] = useState<string | null>(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    const path = location.pathname;
+    if (path === '/main') {
+      setActiveItem('home');
+    } else if (path === '/seniortojunior') {
+      setActiveItem('mentor');
+    } else if (path.startsWith('/portfolio')) {
+      setActiveItem('portfolio');
+    } else if (path.startsWith('/competition')) {
+      setActiveItem('competition');
+    } else {
+      setActiveItem(null);
+    }
+  }, [location.pathname]);
+
+  return activeItem;
+};
+
+export default useSidebar;


### PR DESCRIPTION
#8 

# 메뉴 사이드바(active)수정

## Preview
<img width="1470" alt="스크린샷 2024-07-24 10 49 28" src="https://github.com/user-attachments/assets/2544ef45-987d-4355-a485-ef6f5a0aaba3">

## 수정 및 추가된 사항들

- useLocation 훅을 사용하여 현재 경로를 가져오고 useEffect를 통해 경로가 변경될 때마다 activeItem 상태를 설정함
